### PR TITLE
Add `disableContentType` option, add an option to get upload progress, and add TypeScript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ To use jsonpipe, the server should
      */
     jsonpipe.flow('http://api.com/items?q=batman', {
     	"delimiter": "", // String. The delimiter separating valid JSON objects; default is "\n\n"
+        "onUploadProgress", function(progressEvent) {
+            // Do something with browser's upload progress event
+        },
         "onHeaders": function(statusText, headers) {
             // Do something with the headers and the statusText.
         }
@@ -56,7 +59,8 @@ To use jsonpipe, the server should
         "headers": { // Object. An object of additional header key/value pairs to send along with request
             "X-Requested-With": "XMLHttpRequest"
         },
-        "data": "", // String. A serialized string to be sent in a POST/PUT request,
+        "data": "", // String | FormData | File | Blob. What to be sent in the request body.
+        "disableContentType": false, // By default jsonpipe will set `Content-Type` to "application/x-www-form-urlencoded", you can set `disableContentType` to `true` to skip this behavior. Must set `true` if your `data` is not a string.
         "withCredentials": true // Boolean. Send cookies when making cross-origin requests; default is true
     });
 ```
@@ -66,6 +70,10 @@ To use jsonpipe, the server should
 Type: `String`
 
 The delimiter separating valid JSON objects in the chunked response; default is `\n\n`
+
+### onUploadProgress
+Type: `Function`
+The callback function to be called when browser's native upload progress event triggered.
 
 #### onHeaders
 Type: `Function`
@@ -103,9 +111,14 @@ Type: `Object`
 An object of additional header key/value pairs to send along with request.
 
 #### data
-Type: `String`
+Type: `String` | `FormData` | `File` | `Blob`
 
-A serialized string to be sent in the request body for a POST/PUT request
+What to be sent in the request body. Please note if you would like to send anything rather than `String`, the option `disableContentType` must set to `true`.
+
+#### disableContentType
+Type `Boolean`
+
+By default jsonpipe will set `Content-Type` to "application/x-www-form-urlencoded", you can set `disableContentType` to `true` to skip this behavior. Must set `true` if your `data` is not a string.
 
 ## Testing
 The entire test suite for the jsonpipe API is available in the main test file  [jsonpipe.js](https://github.com/eBay/jsonpipe/blob/master/test/jsonpipe.js). The [mocha-phantomjs](https://github.com/metaskills/mocha-phantomjs) wrapper is used as the testing framework and [chai](http://chaijs.com/api/assert/) for assertion. To run the tests - clone/fork the [repo](https://github.com/eBay/jsonpipe), 

--- a/lib/net/xhr.js
+++ b/lib/net/xhr.js
@@ -46,8 +46,14 @@ function send(url, options) {
         errorFn = options.error || noop,
         completeFn = options.complete || noop,
         disableContentType = options.disableContentType || false,
+        onUploadProgress = options.onUploadProgress,
         addContentHeader = method === 'POST',
         timer;
+
+    // Not all browsers support upload events
+    if (onUploadProgress != null && xhr.upload) {
+      xhr.upload.addEventListener('progress', onUploadProgress);
+    }
 
     xhr.open(method || 'GET', url, true);
 

--- a/lib/net/xhr.js
+++ b/lib/net/xhr.js
@@ -51,7 +51,7 @@ function send(url, options) {
         timer;
 
     // Not all browsers support upload events
-    if (onUploadProgress != null && xhr.upload) {
+    if (typeof onUploadProgress === 'function' && xhr.upload) {
       xhr.upload.addEventListener('progress', onUploadProgress);
     }
 

--- a/lib/net/xhr.js
+++ b/lib/net/xhr.js
@@ -45,6 +45,7 @@ function send(url, options) {
         onHeaders = options.onHeaders || noop,
         errorFn = options.error || noop,
         completeFn = options.complete || noop,
+        disableContentType = options.disableContentType || false,
         addContentHeader = method === 'POST',
         timer;
 
@@ -81,7 +82,7 @@ function send(url, options) {
             }
         }
     }
-    if (addContentHeader) {
+    if (!disableContentType && addContentHeader) {
         xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
     }
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.2",
   "description": "AJAX utility for consuming chunked JSON responses",
   "main": "./lib/jsonpipe.js",
+  "typings": "types.d.ts",
   "scripts": {
     "test": "gulp test",
     "coveralls": "gulp test-cov && gulp report-coveralls && rm -rf coverage && rm -rf lib-cov"

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,20 @@
+export interface Options {
+  delimiter?: string;
+  success?: (data: Record<string, any>) => void;
+  error?: (errorMsg: string) => void;
+  complete?: (statusText: string) => void;
+  timeout?: number;
+  method?: string;
+  headers?: Record<string, string>;
+  data?: string | FormData | File | Blob;
+  disableContentType?: boolean;
+  onUploadProgress?: (progressEvent: ProgressEvent) => void;
+  withCredentials?: boolean;
+}
+
+export interface OptionsWithUrl extends Options {
+  url: string;
+}
+
+export function flow(url: string, options: Options): XMLHttpRequest | undefined;
+export function flow(options: OptionsWithUrl): XMLHttpRequest | undefined;


### PR DESCRIPTION
This PR contains several changes:

- Add `disableContentType` option to fix #19 
- Add an option to get upload progress
- Add TypeScript support