### PR TITLE
Updated code and modules to work with node v12+

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var gulp = require('gulp'),
+require('gulp-clean');
+const gulp = require('gulp'),
     browserify = require('gulp-browserify'),
     replace = require('gulp-replace'),
     mochaPhantomJS = require('gulp-mocha-phantomjs'),
     istanbul = require('gulp-istanbul'),
     istanbulReport = require('gulp-istanbul-report'),
-    coveralls = require('gulp-coveralls'),
-    clean = require('gulp-clean');
+    coveralls = require('gulp-coveralls');
 
 // Build task, to generate the bundled browserify file
-gulp.task('build', function() {
+gulp.task('build', function () {
     return gulp.src('lib/jsonpipe.js')
         .pipe(browserify({
             standalone: "jsonpipe"
@@ -19,25 +19,25 @@ gulp.task('build', function() {
 });
 
 // The watch task
-gulp.task('watch', function() {
+gulp.task('watch', function () {
     gulp.watch('lib/**/*.js', ['build']);
 });
 
-gulp.task('test', ['build'], function() {
+gulp.task('test', gulp.series('build'), function () {
     return gulp.src('test/jsonpipe.html')
         .pipe(mochaPhantomJS());
 });
 
 // Add a task to instrument src files
-gulp.task('instrument', ['build'], function() {
+gulp.task('instrument', gulp.series('build'), function () {
     return gulp.src('./jsonpipe.js')
         .pipe(istanbul({coverageVariable: "__coverage__"}))
         .pipe(gulp.dest('lib-cov/'));
 });
 
 // Add the test coverage task task
-gulp.task('test-cov', ['instrument'], function() {
-    var htmlFile = 'test/jsonpipe.html',
+gulp.task('test-cov', gulp.series('instrument'), function () {
+    const htmlFile = 'test/jsonpipe.html',
         replaceStrs = ['../jsonpipe.js', '../lib-cov/jsonpipe.js'],
         coverageJSON = 'coverage/coverage.json';
 
@@ -51,7 +51,7 @@ gulp.task('test-cov', ['instrument'], function() {
                 coverageFile: coverageJSON
             }
         }))
-        .on('finish', function() {
+        .on('finish', function () {
             // generate coverage.json after finish
             gulp.src(coverageJSON)
                 .pipe(istanbulReport({reporters: ['lcov']}));
@@ -63,10 +63,10 @@ gulp.task('test-cov', ['instrument'], function() {
         });
 });
 
-gulp.task('report-coveralls', function() {
-    return gulp.src('./coverage/lcov.info')
+gulp.task('report-coveralls', function () {
+    return gulp.src('./coverage/lcov.info', {allowEmpty: true})
         .pipe(coveralls());
 });
 
 // Make the default task as test
-gulp.task('default', ['test']);
+gulp.task('default', gulp.series('test'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,7 @@
 'use strict';
 
 require('gulp-clean');
-const gulp = require('gulp'),
+var gulp = require('gulp'),
     browserify = require('gulp-browserify'),
     replace = require('gulp-replace'),
     mochaPhantomJS = require('gulp-mocha-phantomjs'),
@@ -37,7 +37,7 @@ gulp.task('instrument', gulp.series('build'), function () {
 
 // Add the test coverage task task
 gulp.task('test-cov', gulp.series('instrument'), function () {
-    const htmlFile = 'test/jsonpipe.html',
+    var htmlFile = 'test/jsonpipe.html',
         replaceStrs = ['../jsonpipe.js', '../lib-cov/jsonpipe.js'],
         coverageJSON = 'coverage/coverage.json';
 

--- a/jsonpipe.js
+++ b/jsonpipe.js
@@ -2,7 +2,7 @@
 /* eslint no-param-reassign:0 */
 'use strict';
 
-const xhr = _dereq_('./net/xhr'),
+var xhr = _dereq_('./net/xhr'),
     utils = _dereq_('./utils.js'),
     Parser = _dereq_('./parsers/json-chunk'),
     /**
@@ -31,7 +31,7 @@ const xhr = _dereq_('./net/xhr'),
         }
 
         // Init the parser
-        const parser = new Parser(options);
+        var parser = new Parser(options);
 
         // Assign onChunk to options with parse function, binded to the parser object
         options.onChunk = parser.parse.bind(parser);
@@ -46,17 +46,17 @@ module.exports = {
 },{"./net/xhr":2,"./parsers/json-chunk":3,"./utils.js":4}],2:[function(_dereq_,module,exports){
 'use strict';
 
-        const trim = ''.trim
-            ? function (s) {
-                return s.trim();
-            }
-            : function (s) {
-                return s.replace(/(^\s*|\s*$)/g, '');
-            };
+var trim = ''.trim
+    ? function (s) {
+        return s.trim();
+    }
+    : function (s) {
+        return s.replace(/(^\s*|\s*$)/g, '');
+    };
 
 function parseHeader(str) {
-    const lines = str.split(/\r?\n/);
-    const fields = {};
+    var lines = str.split(/\r?\n/);
+    var fields = {};
     let index;
     let line;
     let field;
@@ -65,7 +65,7 @@ function parseHeader(str) {
     lines.pop(); // trailing CRLF
 
     let i = 0;
-    const len = lines.length;
+    var len = lines.length;
     for (; i < len; ++i) {
         line = lines[i];
         index = line.indexOf(':');
@@ -82,7 +82,7 @@ function send(url, options) {
         return undefined;
     }
 
-    const xhr = new XMLHttpRequest(),
+    var xhr = new XMLHttpRequest(),
         state = {
             UNSENT: 0,
             OPENED: 1,
@@ -172,7 +172,7 @@ module.exports = {
 },{}],3:[function(_dereq_,module,exports){
 'use strict';
 
-        const utils = _dereq_('../utils.js');
+        var utils = _dereq_('../utils.js');
 
 function Parser(options) {
     this.offset = 0;
@@ -194,23 +194,23 @@ function Parser(options) {
             // Re-assign finish to the next token
             finish = chunk.indexOf(this.token, start);
 
-    while (finish > -1) {
-        subChunk = chunk.substring(start, finish);
-        if (subChunk) {
-            utils.parse(subChunk, this.success, this.error);
-        }
-        start = finish + this.token.length; // move the start
-        finish = chunk.indexOf(this.token, start); // Re-assign finish to the next token
-    }
-    this.offset += start; // move the offset
+            while (finish > -1) {
+                subChunk = chunk.substring(start, finish);
+                if (subChunk) {
+                    utils.parse(subChunk, this.success, this.error);
+                }
+                start = finish + this.token.length; // move the start
+                finish = chunk.indexOf(this.token, start); // Re-assign finish to the next token
+            }
+            this.offset += start; // move the offset
 
             // Get the remaining chunk
-    chunk = text.substring(this.offset);
-    // If final chunk and still unprocessed chunk and no delimiter, then execute the full chunk
-    if (finalChunk && chunk && finish === -1) {
-        utils.parse(chunk, this.success, this.error);
-    }
-};
+            chunk = text.substring(this.offset);
+            // If final chunk and still unprocessed chunk and no delimiter, then execute the full chunk
+            if (finalChunk && chunk && finish === -1) {
+                utils.parse(chunk, this.success, this.error);
+            }
+        };
 
 module.exports = Parser;
 

--- a/jsonpipe.js
+++ b/jsonpipe.js
@@ -2,7 +2,7 @@
 /* eslint no-param-reassign:0 */
 'use strict';
 
-const xhr = _dereq_('./net/xhr'),
+var xhr = _dereq_('./net/xhr'),
     utils = _dereq_('./utils.js'),
     Parser = _dereq_('./parsers/json-chunk'),
     /**
@@ -31,7 +31,7 @@ const xhr = _dereq_('./net/xhr'),
         }
 
         // Init the parser
-        const parser = new Parser(options);
+        var parser = new Parser(options);
 
         // Assign onChunk to options with parse function, binded to the parser object
         options.onChunk = parser.parse.bind(parser);
@@ -46,7 +46,7 @@ module.exports = {
 },{"./net/xhr":2,"./parsers/json-chunk":3,"./utils.js":4}],2:[function(_dereq_,module,exports){
 'use strict';
 
-        const trim = ''.trim
+        var trim = ''.trim
             ? function (s) {
                 return s.trim();
             }
@@ -55,8 +55,8 @@ module.exports = {
             };
 
 function parseHeader(str) {
-    const lines = str.split(/\r?\n/);
-    const fields = {};
+    var lines = str.split(/\r?\n/);
+    var fields = {};
     let index;
     let line;
     let field;
@@ -65,7 +65,7 @@ function parseHeader(str) {
     lines.pop(); // trailing CRLF
 
     let i = 0;
-    const len = lines.length;
+    var len = lines.length;
     for (; i < len; ++i) {
         line = lines[i];
         index = line.indexOf(':');
@@ -82,7 +82,7 @@ function send(url, options) {
         return undefined;
     }
 
-    const xhr = new XMLHttpRequest(),
+    var xhr = new XMLHttpRequest(),
         state = {
             UNSENT: 0,
             OPENED: 1,
@@ -172,7 +172,7 @@ module.exports = {
 },{}],3:[function(_dereq_,module,exports){
 'use strict';
 
-        const utils = _dereq_('../utils.js');
+        var utils = _dereq_('../utils.js');
 
 function Parser(options) {
     this.offset = 0;
@@ -194,15 +194,15 @@ function Parser(options) {
             // Re-assign finish to the next token
             finish = chunk.indexOf(this.token, start);
 
-    while (finish > -1) {
-        subChunk = chunk.substring(start, finish);
-        if (subChunk) {
-            utils.parse(subChunk, this.success, this.error);
-        }
-        start = finish + this.token.length; // move the start
-        finish = chunk.indexOf(this.token, start); // Re-assign finish to the next token
-    }
-    this.offset += start; // move the offset
+            while (finish > -1) {
+                subChunk = chunk.substring(start, finish);
+                if (subChunk) {
+                    utils.parse(subChunk, this.success, this.error);
+                }
+                start = finish + this.token.length; // move the start
+                finish = chunk.indexOf(this.token, start); // Re-assign finish to the next token
+            }
+            this.offset += start; // move the offset
 
             // Get the remaining chunk
     chunk = text.substring(this.offset);

--- a/jsonpipe.js
+++ b/jsonpipe.js
@@ -2,7 +2,7 @@
 /* eslint no-param-reassign:0 */
 'use strict';
 
-var xhr = _dereq_('./net/xhr'),
+const xhr = _dereq_('./net/xhr'),
     utils = _dereq_('./utils.js'),
     Parser = _dereq_('./parsers/json-chunk'),
     /**
@@ -11,7 +11,7 @@ var xhr = _dereq_('./net/xhr'),
      * @return {XMLHttpRequest} The XMLHttpRequest object for this request.
      * @method ajax
      */
-    ajax = function(url, options) {
+    ajax = function (url, options) {
         // Do all prerequisite checks
         if (!url) {
             return undefined;
@@ -31,7 +31,7 @@ var xhr = _dereq_('./net/xhr'),
         }
 
         // Init the parser
-        var parser = new Parser(options);
+        const parser = new Parser(options);
 
         // Assign onChunk to options with parse function, binded to the parser object
         options.onChunk = parser.parse.bind(parser);
@@ -46,21 +46,27 @@ module.exports = {
 },{"./net/xhr":2,"./parsers/json-chunk":3,"./utils.js":4}],2:[function(_dereq_,module,exports){
 'use strict';
 
-var trim = ''.trim
-  ? function(s) { return s.trim(); }
-  : function(s) { return s.replace(/(^\s*|\s*$)/g, ''); };
+        const trim = ''.trim
+            ? function (s) {
+                return s.trim();
+            }
+            : function (s) {
+                return s.replace(/(^\s*|\s*$)/g, '');
+            };
 
 function parseHeader(str) {
-    var lines = str.split(/\r?\n/);
-    var fields = {};
-    var index;
-    var line;
-    var field;
-    var val;
+    const lines = str.split(/\r?\n/);
+    const fields = {};
+    let index;
+    let line;
+    let field;
+    let val;
 
     lines.pop(); // trailing CRLF
 
-    for (var i = 0, len = lines.length; i < len; ++i) {
+    let i = 0;
+    const len = lines.length;
+    for (; i < len; ++i) {
         line = lines[i];
         index = line.indexOf(':');
         field = line.slice(0, index).toLowerCase();
@@ -76,7 +82,7 @@ function send(url, options) {
         return undefined;
     }
 
-    var xhr = new XMLHttpRequest(),
+    const xhr = new XMLHttpRequest(),
         state = {
             UNSENT: 0,
             OPENED: 1,
@@ -84,20 +90,28 @@ function send(url, options) {
             LOADING: 3,
             DONE: 4
         },
-        noop = function() {},
+        noop = function () {
+        },
         method = (options.method || '').toUpperCase(),
         headers = options.headers,
         onChunk = options.onChunk || noop,
         onHeaders = options.onHeaders || noop,
         errorFn = options.error || noop,
         completeFn = options.complete || noop,
-        addContentHeader = method === 'POST',
+        disableContentType = options.disableContentType || false,
+        onUploadProgress = options.onUploadProgress;
+    let addContentHeader = method === 'POST',
         timer;
+
+    // Not all browsers support upload events
+    if (typeof onUploadProgress === 'function' && xhr.upload) {
+        xhr.upload.addEventListener('progress', onUploadProgress);
+    }
 
     xhr.open(method || 'GET', url, true);
 
     // Attach onreadystatechange
-    xhr.onreadystatechange = function() {
+    xhr.onreadystatechange = function () {
         if (xhr.readyState === state.HEADERS_RECEIVED) {
             onHeaders(xhr.statusText, parseHeader(xhr.getAllResponseHeaders()));
         } else if (xhr.readyState === state.LOADING) {
@@ -120,20 +134,20 @@ function send(url, options) {
 
     // Add headers
     if (headers) {
-        for (var key in headers) { // eslint-disable-line guard-for-in
+        for (let key in headers) { // eslint-disable-line guard-for-in
             xhr.setRequestHeader(key, headers[key]);
             if (key.toLowerCase() === 'content-type') {
                 addContentHeader = false;
             }
         }
     }
-    if (addContentHeader) {
+    if (!disableContentType && addContentHeader) {
         xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
     }
 
     // Add timeout
     if (options.timeout) {
-        timer = setTimeout(function() {
+        timer = setTimeout(function () {
             xhr.abort();
             clearTimeout(timer);
         }, options.timeout);
@@ -158,7 +172,7 @@ module.exports = {
 },{}],3:[function(_dereq_,module,exports){
 'use strict';
 
-var utils = _dereq_('../utils.js');
+        const utils = _dereq_('../utils.js');
 
 function Parser(options) {
     this.offset = 0;
@@ -167,18 +181,18 @@ function Parser(options) {
     this.error = options.error;
 }
 
-Parser.prototype.parse = function(text, finalChunk) {
-    var chunk = text.substring(this.offset),
-        start = 0,
-        finish = chunk.indexOf(this.token, start),
-        subChunk;
+        Parser.prototype.parse = function (text, finalChunk) {
+            let chunk = text.substring(this.offset),
+                start = 0,
+                finish = chunk.indexOf(this.token, start),
+                subChunk;
 
-    if (finish === 0) { // The delimiter is at the beginning so move the start
-        start = this.token.length;
-    }
+            if (finish === 0) { // The delimiter is at the beginning so move the start
+                start = this.token.length;
+            }
 
-    // Re-assign finish to the next token
-    finish = chunk.indexOf(this.token, start);
+            // Re-assign finish to the next token
+            finish = chunk.indexOf(this.token, start);
 
     while (finish > -1) {
         subChunk = chunk.substring(start, finish);
@@ -190,7 +204,7 @@ Parser.prototype.parse = function(text, finalChunk) {
     }
     this.offset += start; // move the offset
 
-    // Get the remaning chunk
+            // Get the remaining chunk
     chunk = text.substring(this.offset);
     // If final chunk and still unprocessed chunk and no delimiter, then execute the full chunk
     if (finalChunk && chunk && finish === -1) {
@@ -214,14 +228,14 @@ function isFunction(fn) {
 
 // Do the eval trick, since JSON object not present
 function customParse(chunk) {
-    if (!chunk || !/^[\{|\[].*[\}|\]]$/.test(chunk)) {
+    if (!chunk || !/^[{|\[].*[}|\]]$/.test(chunk)) {
         throw new Error('parseerror');
     }
     return eval('(' + chunk + ')'); // eslint-disable-line no-eval
 }
 
 function parse(chunk, successCb, errorCb) {
-    var jsonObj;
+    let jsonObj;
     try {
         jsonObj = typeof JSON !== 'undefined' ? JSON.parse(chunk) : customParse(chunk);
     } catch (ex) {

--- a/lib/jsonpipe.js
+++ b/lib/jsonpipe.js
@@ -1,7 +1,7 @@
 /* eslint no-param-reassign:0 */
 'use strict';
 
-var xhr = require('./net/xhr'),
+const xhr = require('./net/xhr'),
     utils = require('./utils.js'),
     Parser = require('./parsers/json-chunk'),
     /**
@@ -10,7 +10,7 @@ var xhr = require('./net/xhr'),
      * @return {XMLHttpRequest} The XMLHttpRequest object for this request.
      * @method ajax
      */
-    ajax = function(url, options) {
+    ajax = function (url, options) {
         // Do all prerequisite checks
         if (!url) {
             return undefined;
@@ -30,7 +30,7 @@ var xhr = require('./net/xhr'),
         }
 
         // Init the parser
-        var parser = new Parser(options);
+        const parser = new Parser(options);
 
         // Assign onChunk to options with parse function, binded to the parser object
         options.onChunk = parser.parse.bind(parser);

--- a/lib/jsonpipe.js
+++ b/lib/jsonpipe.js
@@ -1,7 +1,7 @@
 /* eslint no-param-reassign:0 */
 'use strict';
 
-const xhr = require('./net/xhr'),
+var xhr = require('./net/xhr'),
     utils = require('./utils.js'),
     Parser = require('./parsers/json-chunk'),
     /**
@@ -30,7 +30,7 @@ const xhr = require('./net/xhr'),
         }
 
         // Init the parser
-        const parser = new Parser(options);
+        var parser = new Parser(options);
 
         // Assign onChunk to options with parse function, binded to the parser object
         options.onChunk = parser.parse.bind(parser);

--- a/lib/net/xhr.js
+++ b/lib/net/xhr.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const trim = ''.trim
+var trim = ''.trim
     ? function (s) {
         return s.trim();
     }
@@ -9,8 +9,8 @@ const trim = ''.trim
     };
 
 function parseHeader(str) {
-    const lines = str.split(/\r?\n/);
-    const fields = {};
+    var lines = str.split(/\r?\n/);
+    var fields = {};
     let index;
     let line;
     let field;
@@ -19,7 +19,7 @@ function parseHeader(str) {
     lines.pop(); // trailing CRLF
 
     let i = 0;
-    const len = lines.length;
+    var len = lines.length;
     for (; i < len; ++i) {
         line = lines[i];
         index = line.indexOf(':');
@@ -36,7 +36,7 @@ function send(url, options) {
         return undefined;
     }
 
-    const xhr = new XMLHttpRequest(),
+    var xhr = new XMLHttpRequest(),
         state = {
             UNSENT: 0,
             OPENED: 1,

--- a/lib/net/xhr.js
+++ b/lib/net/xhr.js
@@ -1,20 +1,26 @@
 'use strict';
 
-var trim = ''.trim
-  ? function(s) { return s.trim(); }
-  : function(s) { return s.replace(/(^\s*|\s*$)/g, ''); };
+const trim = ''.trim
+    ? function (s) {
+        return s.trim();
+    }
+    : function (s) {
+        return s.replace(/(^\s*|\s*$)/g, '');
+    };
 
 function parseHeader(str) {
-    var lines = str.split(/\r?\n/);
-    var fields = {};
-    var index;
-    var line;
-    var field;
-    var val;
+    const lines = str.split(/\r?\n/);
+    const fields = {};
+    let index;
+    let line;
+    let field;
+    let val;
 
     lines.pop(); // trailing CRLF
 
-    for (var i = 0, len = lines.length; i < len; ++i) {
+    let i = 0;
+    const len = lines.length;
+    for (; i < len; ++i) {
         line = lines[i];
         index = line.indexOf(':');
         field = line.slice(0, index).toLowerCase();
@@ -30,7 +36,7 @@ function send(url, options) {
         return undefined;
     }
 
-    var xhr = new XMLHttpRequest(),
+    const xhr = new XMLHttpRequest(),
         state = {
             UNSENT: 0,
             OPENED: 1,
@@ -38,7 +44,8 @@ function send(url, options) {
             LOADING: 3,
             DONE: 4
         },
-        noop = function() {},
+        noop = function () {
+        },
         method = (options.method || '').toUpperCase(),
         headers = options.headers,
         onChunk = options.onChunk || noop,
@@ -46,19 +53,19 @@ function send(url, options) {
         errorFn = options.error || noop,
         completeFn = options.complete || noop,
         disableContentType = options.disableContentType || false,
-        onUploadProgress = options.onUploadProgress,
-        addContentHeader = method === 'POST',
+        onUploadProgress = options.onUploadProgress;
+    let addContentHeader = method === 'POST',
         timer;
 
     // Not all browsers support upload events
     if (typeof onUploadProgress === 'function' && xhr.upload) {
-      xhr.upload.addEventListener('progress', onUploadProgress);
+        xhr.upload.addEventListener('progress', onUploadProgress);
     }
 
     xhr.open(method || 'GET', url, true);
 
     // Attach onreadystatechange
-    xhr.onreadystatechange = function() {
+    xhr.onreadystatechange = function () {
         if (xhr.readyState === state.HEADERS_RECEIVED) {
             onHeaders(xhr.statusText, parseHeader(xhr.getAllResponseHeaders()));
         } else if (xhr.readyState === state.LOADING) {
@@ -81,7 +88,7 @@ function send(url, options) {
 
     // Add headers
     if (headers) {
-        for (var key in headers) { // eslint-disable-line guard-for-in
+        for (let key in headers) { // eslint-disable-line guard-for-in
             xhr.setRequestHeader(key, headers[key]);
             if (key.toLowerCase() === 'content-type') {
                 addContentHeader = false;
@@ -94,7 +101,7 @@ function send(url, options) {
 
     // Add timeout
     if (options.timeout) {
-        timer = setTimeout(function() {
+        timer = setTimeout(function () {
             xhr.abort();
             clearTimeout(timer);
         }, options.timeout);

--- a/lib/parsers/json-chunk.js
+++ b/lib/parsers/json-chunk.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var utils = require('../utils.js');
+const utils = require('../utils.js');
 
 function Parser(options) {
     this.offset = 0;
@@ -9,8 +9,8 @@ function Parser(options) {
     this.error = options.error;
 }
 
-Parser.prototype.parse = function(text, finalChunk) {
-    var chunk = text.substring(this.offset),
+Parser.prototype.parse = function (text, finalChunk) {
+    let chunk = text.substring(this.offset),
         start = 0,
         finish = chunk.indexOf(this.token, start),
         subChunk;
@@ -32,7 +32,7 @@ Parser.prototype.parse = function(text, finalChunk) {
     }
     this.offset += start; // move the offset
 
-    // Get the remaning chunk
+    // Get the remaining chunk
     chunk = text.substring(this.offset);
     // If final chunk and still unprocessed chunk and no delimiter, then execute the full chunk
     if (finalChunk && chunk && finish === -1) {

--- a/lib/parsers/json-chunk.js
+++ b/lib/parsers/json-chunk.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const utils = require('../utils.js');
+var utils = require('../utils.js');
 
 function Parser(options) {
     this.offset = 0;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,14 +10,14 @@ function isFunction(fn) {
 
 // Do the eval trick, since JSON object not present
 function customParse(chunk) {
-    if (!chunk || !/^[\{|\[].*[\}|\]]$/.test(chunk)) {
+    if (!chunk || !/^[{|\[].*[}|\]]$/.test(chunk)) {
         throw new Error('parseerror');
     }
     return eval('(' + chunk + ')'); // eslint-disable-line no-eval
 }
 
 function parse(chunk, successCb, errorCb) {
-    var jsonObj;
+    let jsonObj;
     try {
         jsonObj = typeof JSON !== 'undefined' ? JSON.parse(chunk) : customParse(chunk);
     } catch (ex) {

--- a/package.json
+++ b/package.json
@@ -15,18 +15,19 @@
   "author": "Senthil Padmanabhan <https://twitter.com/senthil_hi>",
   "license": "MIT",
   "devDependencies": {
-    "gulp": "~3.8.11",
+    "gulp": "^4.0.2",
     "gulp-browserify": "~0.5.1",
-    "gulp-clean": "^0.3.1",
+    "gulp-clean": "^0.4.0",
     "gulp-coveralls": "^0.1.4",
-    "gulp-istanbul": "^0.10.3",
-    "gulp-istanbul-report": "0.0.1",
-    "gulp-mocha-phantomjs": "^0.10.1",
-    "gulp-replace": "^0.5.4",
-    "mocha-lcov-reporter": "^1.0.0",
-    "mocha-phantomjs-istanbul": "0.0.2"
+    "gulp-istanbul": "^1.1.3",
+    "gulp-istanbul-report": "^0.0.1",
+    "gulp-mocha-phantomjs": "^0.12.2",
+    "gulp-replace": "^1.0.0",
+    "mocha-lcov-reporter": "^1.3.0",
+    "mocha-phantomjs-istanbul": "^0.0.2"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
Newer versions of node(>12) no longer worked with gulp 3.x which was in use in this package. 

I have upgraded gulp to v4.0.2, and also upgraded some of the other gulp associated dependencies. 
I have modified the code to work with these newer versions, as well as doing a code cleanup without modifying any behaviour.

Signed-off-by: Brian Evans <ebrian101@gmail.com>